### PR TITLE
Update ng-file-drop.directive.ts to check if they are any subscriptions to unsubscribe

### DIFF
--- a/projects/ngx-uploader/src/lib/ng-file-drop.directive.ts
+++ b/projects/ngx-uploader/src/lib/ng-file-drop.directive.ts
@@ -46,7 +46,9 @@ export class NgFileDropDirective implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this._sub.forEach(sub => sub.unsubscribe());
+      if(this._sub) {
+        this._sub.forEach(sub => sub.unsubscribe())
+      }
   }
 
   stopEvent = (e: Event) => {


### PR DESCRIPTION
…n before trying to unsubscribe.

This is to prevent the following error from occurring: ERROR TypeError: Cannot read property 'forEach' of undefined at NgFileDropDirective.ngOnDestroy